### PR TITLE
Advantech webaccess dashboard file upload

### DIFF
--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -112,7 +112,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    return unless vuln_version?
+    unless vuln_version?
+      print_status("#{peer} - Cannot reliably check exploitability.")
+      return
+    end
     filename = "#{Rex::Text.rand_text_alpha(5)}.aspx"
     filedata = Msf::Util::EXE.to_exe_aspx(generate_payload_exe)
 

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    ver = version_match(res.body)
+    ver = res && res.body ? version_match(res.body) : nil
     true ? Gem::Version.new(ver) == Gem::Version.new('8.0') : false
   end
 


### PR DESCRIPTION
- Fix res ```NilClass``` bug
- an extra ```print_status``` or something like that to inform the user about the non-vulnerable version
- Find ```#send_reqeuest_cgi!``` bug

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploits/windows/scada/advantech_webaccess_dashboard_file_upload`


